### PR TITLE
Create NS_TimeZoneConverterTest

### DIFF
--- a/ADS_TimeZoneConverterTest
+++ b/ADS_TimeZoneConverterTest
@@ -1,0 +1,41 @@
+using NUnit.Framework;
+using System;
+using TestProject1.TimeConverter;
+
+
+namespace TestProject1
+{
+    [TestFixture]
+    public class TimeZoneConverterTest
+    {
+
+        [Test]
+        public void ConvertToEstTest()
+        {
+            // Arrange
+            var actualDateTime = DateTime.Now;
+            var estTime = TimeZoneConverter.ConvertToEst(actualDateTime);
+
+            // Act
+            TimeZoneInfo easternZone = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
+            var dt = TimeZoneInfo.ConvertTime(actualDateTime, TimeZoneInfo.Local, easternZone);
+
+            // Assert
+            Assert.AreEqual(dt, estTime);
+        }
+
+        [Test]
+        public void ConvertToUtcTest()
+        {
+            // Arrange
+            var actualDateTime = DateTime.Now;
+            var utcTime = TimeZoneInfo.ConvertTimeToUtc(actualDateTime);
+
+            // Act
+            var actual = TimeZoneConverter.ConvertToUtc(actualDateTime);
+
+            // Assert
+            Assert.AreEqual(utcTime, actual);
+        }
+    }
+}

--- a/AK_TimeZoneConverterTest
+++ b/AK_TimeZoneConverterTest
@@ -1,0 +1,42 @@
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TestProject1.TimeConverter
+{
+    [TestFixture]
+    class TimeZoneConverterTest
+    {
+        [Test]
+        public void CheckConvertToEst()
+        {
+            //Arrange
+            var dateTimeNow = DateTime.Now;
+            var expected = TimeZoneInfo.ConvertTime(dateTimeNow, TimeZoneInfo.Local, TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time"));
+
+            //Act
+            var converted = TimeZoneConverter.ConvertToEst(dateTimeNow);
+
+            //Assert
+            Assert.AreEqual(expected.Day, converted.Day);
+            Assert.AreEqual(expected.Hour, converted.Hour);
+            Assert.AreEqual(expected.Minute, converted.Minute);
+        }
+        [Test]
+        public void CheckConvertToUtc()
+        {
+            //Arrange
+            var dateTimeNow = DateTime.Now;
+            var expected = TimeZoneInfo.ConvertTimeToUtc(dateTimeNow);
+
+            //Act
+            var converted = TimeZoneConverter.ConvertToUtc(dateTimeNow);
+            //Assert
+
+            Assert.AreEqual(expected.Day, converted.Day);
+            Assert.AreEqual(expected.Hour, converted.Hour);
+            Assert.AreEqual(expected.Minute, converted.Minute);
+        }
+    }
+}

--- a/Homework!!!
+++ b/Homework!!!
@@ -1,0 +1,5 @@
+Write three classes: Student, Course and School. Students should have name and unique number (inside the entire School). Name can not be empty and the unique number is between 10000 and 99999. Each course contains a set of students. Students in a course should be less than 30 and can join and leave courses.
+Write following unit tests: 
+1. Verify max number of students in group.
+2. Check whether number entire School is unique.
+3. Student Name cannot be empty.

--- a/KhromiakTimeZoneConverterTest
+++ b/KhromiakTimeZoneConverterTest
@@ -1,0 +1,30 @@
+using System;
+using NUnit.Framework;
+
+namespace Tests
+{
+    public class TimeZoneConverterTest
+    {
+        [Test]
+        public void ConvertToEstTest()
+        {
+            DateTime dataTime = new DateTime(2008, 5, 1, 8, 30, 52);
+            DateTime expectedDataTime = new DateTime(2008, 5, 1, 1, 30, 52);
+
+            dataTime = TimeZoneConverter.ConvertToEst(dataTime);
+
+            Assert.AreEqual(expectedDataTime, dataTime);
+        }
+
+        [Test]
+        public void ConvertToUtcTest()
+        {
+            DateTime dataTime = new DateTime(2008, 5, 1, 8, 30, 52);
+            DateTime expectedDataTime = new DateTime(2008, 5, 1, 6, 30, 52);
+
+            dataTime = TimeZoneConverter.ConvertToUtc(dataTime);
+
+            Assert.AreEqual(expectedDataTime, dataTime);
+        }
+    }
+}

--- a/PP_TimeZoneConverterTest
+++ b/PP_TimeZoneConverterTest
@@ -1,0 +1,37 @@
+using NUnit.Framework;
+using System;
+using TestProject1.TimeConverter;
+
+namespace TestProject1
+{
+    [TestFixture]
+    public class TimeConverterTest
+    {
+        [Test]
+        public void Check_Convert_To_Est()
+        {
+            //Arrange
+            var date = DateTime.Now;
+            var timeZone = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
+
+            //Act
+            var expectedEst = TimeZoneInfo.ConvertTime(date, TimeZoneInfo.Local, timeZone);
+
+            //Assert
+            Assert.AreEqual(expectedEst, TimeZoneConverter.ConvertToEst(date));
+        }
+
+        [Test]
+        public void Check_Convert_To_Utc()
+        {
+            //Arrange
+            var date = DateTime.Now;
+
+            //Act
+            var expectedEst = TimeZoneInfo.ConvertTimeToUtc(date);
+
+            //Assert
+            Assert.AreEqual(expectedEst, TimeZoneConverter.ConvertToUtc(date));
+        }
+    }
+}

--- a/PP_UserRepositoryTest
+++ b/PP_UserRepositoryTest
@@ -1,0 +1,31 @@
+using NUnit.Framework;
+using System;
+using TestProject2.BL;
+using Moq;
+
+namespace TestProject2
+{
+    [TestFixture]
+    public class MockUserRepoTest
+    {
+        [Test]
+        public void Get_User_By_Id_Returns_User()
+        {
+            var mock = new Mock<IUserRepository>();
+
+            mock.Setup(x => x.GetUserInfo(It.IsAny<int>())).Returns(new User());
+
+            var actualUser = mock.Object.GetUserInfo(1);
+
+            Assert.NotNull(actualUser);
+        }
+
+        [Test]
+        public void ThrowsWhenUserNotExist()
+        {
+            var repo = new UserRepository();
+
+            Assert.Throws<NullReferenceException>(() => repo.GetUserInfo(-1));
+        }
+    }
+}

--- a/RO_TimeZoneConverterTest
+++ b/RO_TimeZoneConverterTest
@@ -1,0 +1,38 @@
+namespace TestProject1
+{
+    using NUnit.Framework;
+    using System;
+    using TestProject1.TimeConverter;
+
+    public class TimeZoneConverterTest
+    {
+        [Test]
+        public void ConvertsToUtc()
+        {
+            //Arrange
+            DateTime currentDateTime = DateTime.Now;
+            DateTime expectedUtcDateTime = TimeZoneInfo.ConvertTimeToUtc(currentDateTime);
+
+            //Act
+            DateTime actualUtcDateTime = TimeZoneConverter.ConvertToUtc(currentDateTime);
+
+            //Assert
+            Assert.AreEqual(expectedUtcDateTime, actualUtcDateTime);
+        }
+
+        [Test]
+        public void ConvertsToEst()
+        {
+            //Arrange
+            DateTime currentDateTime = DateTime.Now;
+            TimeZoneInfo easternZone = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
+            DateTime expectedEstDateTime = TimeZoneInfo.ConvertTime(currentDateTime, TimeZoneInfo.Local, easternZone);
+
+            //Act
+            DateTime actualEstDateTime = TimeZoneConverter.ConvertToEst(currentDateTime);
+
+            //Assert
+            Assert.AreEqual(expectedEstDateTime, actualEstDateTime);
+        }
+    }
+}


### PR DESCRIPTION
using NUnit.Framework;
using System;

namespace TestProject1.TimeZoneConverter
{
    [TestFixture]
    public class TimeZoneConverterTest
    {
        [Test]
        public void CheckConvertToEst()
        {
            //arrange
            var currentTime = DateTime.Now;
            TimeZoneInfo easternZone = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
            var expectedResult = TimeZoneInfo.ConvertTime(currentTime, TimeZoneInfo.Local, easternZone);

            //act
            var actualResult = TimeZoneConverter.ConvertToEst(currentTime);

            //assert
            Assert.AreEqual(expectedResult, actualResult);
        }

        [Test]
        public void CheckConvertToUts()
        {           
            //arrange
            var currentTime = DateTime.Now;
            var expectedResult = TimeZoneInfo.ConvertTimeToUtc(currentTime);

            //act
            var actualResult = TimeZoneConverter.ConvertToUtc(currentTime);

            //assert
            Assert.AreEqual(expectedResult, actualResult);
        }
    }
}